### PR TITLE
force anytype to be string to work with parquet

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -170,7 +170,7 @@ def field_to_property_schema(field, mdata): # pylint:disable=too-many-branches
     elif sf_type == "time":
         property_schema['type'] = "string"
     elif sf_type in LOOSE_TYPES:
-        return property_schema, mdata  # No type = all types
+        property_schema['type'] = "string"
     elif sf_type in BINARY_TYPES:
         mdata = metadata.write(mdata, ('properties', field_name), "inclusion", "unsupported")
         mdata = metadata.write(mdata, ('properties', field_name),


### PR DESCRIPTION
# Description of change
Force Loose types (anytype and calculated type) to be strings, so output can work with target-parquet.