### PR TITLE
add support to fetch xlsx reports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='tap-salesforce',
       install_requires=[
           'requests>=2.20.0,<=2.29.0',
           'singer-python==5.3.1',
-          'xmltodict==0.11.0'
+          'xmltodict==0.11.0',
+          'openpyxl==3.1.5'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -101,6 +101,8 @@ def create_property_schema(field, mdata, is_report=False):
     else:
         mdata = metadata.write(
             mdata, ('properties', field_name), 'inclusion', 'available')
+        if is_report:
+            mdata[('properties', field_name)]["field_metadata"] = field
 
     property_schema, mdata = tap_salesforce.salesforce.field_to_property_schema(field, mdata, is_report)
 


### PR DESCRIPTION
# Description of change
Add support to fetch xlsx reports

# Config flags to enable:
```
    "list_reports": true,
    "discover_report_fields": true,
```
**xlsx reports available from version "43.0"**:

`  "api_version": "43.0"`

Accepts custom reportMetadata to sort and filter reports, via config file.
example:

```
    "report_metadata": [
        {
            "Sales_October_Report": {
                "reportMetadata": {
                    "reportFilters": [
                        {
                            "column": "Product.Name",
                            "operator": "greaterThan",
                            "value": "1 1/4 ADAPTER"
                        }
                    ],
                    "sortBy": [
                        {
                            "sortColumn": "Product.Name",
                            "sortOrder": "Asc"
                        }
                    ]
                }
            }
        }
    ]
```
Notes: 
Report Name should be the `DeveloperName` and the fields name for sorting and filtering should be the `entityColumnName` not the label shown in the report.