### PR TITLE
Feature/hgi 7326 - Handle deleted/malformed Reports and ListViews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ config.json
 .autoenv.zsh
 
 *~
+
+.vscode
+.venv

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -296,6 +296,10 @@ class Salesforce():
         try:
             resp.raise_for_status()
         except RequestException as ex:
+            if resp.status_code == 500 and 'List view filter is not FilterByDynsql Context' in resp.text:
+                # Corrupted list view, skip it
+                LOGGER.warning(f"Skipping list view {url} due to corrupted filter")
+                raise ex
             if 500 <= resp.status_code <600:
                 raise RetriableError(ex)
             raise ex


### PR DESCRIPTION
This PR adds 3 fixes:
- Excludes deleted reports from the catalog during discover
- Excludes reports with greater than 100 columns on discover (Because they cannot be synced)
- Avoid retrying on corrupted ListViews
