### PR TITLE
HGI-8615: Fix column validation for grouped reports

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -282,7 +282,9 @@ def validate_report(sf, report, valid_reports):
             raise e
     
     columns = report_metadata.get('reportMetadata', {}).get('detailColumns', [])
-    if len(columns) > 100:
+    # multi block reports (grouped) don't have detailColumns, so columns could be None
+    # tap is handling fetching records for multi block reports (grouped) in get_report_record_ids
+    if columns is not None and len(columns) > 100:
         LOGGER.warning("Skipping report %s, as it has more than 100 columns", report["DeveloperName"])
         return
     


### PR DESCRIPTION
# Description of change
The code was failing for multi-block (grouped) reports because it was trying to validate the length of detailColumns, and grouped reports don't have it.
Added a null check for the columns variable before validating its length

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
