### PR TITLE
HGi-8814: Add chunked query execution for large record sets

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -641,8 +641,8 @@ def do_sync(sf, catalog, state,config=None):
                                               catalog_entry['tap_stream_id'],
                                               'version',
                                               stream_version)
-            counter = sync_stream(sf, catalog_entry, state, input_state, catalog,config)
-            LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter.value)
+            counter_value = sync_stream(sf, catalog_entry, state, input_state, catalog,config)
+            LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter_value)
 
     state["current_stream"] = None
     singer.write_state(state)


### PR DESCRIPTION
- Updated sync_stream to return counter value directly.
- Introduced _chunk_list and _execute_chunked_query functions to handle large record IDs in chunks.
- Enhanced sync_filtered_accounts to utilize chunked queries for better performance and reliability.

# Description of change
(write a short description here or paste a link to JIRA)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
