### PR TITLE
Handle missing Salesforce reports explicitly

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -12,7 +12,7 @@ from tap_salesforce.salesforce.exceptions import (
     TapSalesforceException,
     TapSalesforceBulkAPIDisabledException,
     TapSalesforceQuotaExceededException,
-    TapSalesforceReportRetrievalException,
+    TapSalesforceReportNotFoundException,
 )
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from hotglue_singer_sdk.tap_base import Tap
@@ -719,7 +719,7 @@ class SalesforceTap(Tap):
     exception_alerting_level_map = {
         TapSalesforceQuotaExceededException: AlertingLevel.NONE,
         InvalidCredentialsError: AlertingLevel.NONE,
-        TapSalesforceReportRetrievalException: AlertingLevel.NONE,
+        TapSalesforceReportNotFoundException: AlertingLevel.NONE,
     }
 
     config_jsonschema = th.PropertiesList(

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -9,7 +9,11 @@ from tap_salesforce.sync import (sync_stream, resume_syncing_bulk_query, get_str
 from tap_salesforce.salesforce import Salesforce
 from tap_salesforce.salesforce.bulk import Bulk
 from tap_salesforce.salesforce.exceptions import (
-    TapSalesforceException, TapSalesforceBulkAPIDisabledException, TapSalesforceQuotaExceededException)
+    TapSalesforceException,
+    TapSalesforceBulkAPIDisabledException,
+    TapSalesforceQuotaExceededException,
+    TapSalesforceReportRetrievalException,
+)
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from hotglue_singer_sdk.tap_base import Tap
 from hotglue_singer_sdk.helpers._util import read_json_file
@@ -714,7 +718,8 @@ class SalesforceTap(Tap):
     alerting_level = AlertingLevel.WARNING
     exception_alerting_level_map = {
         TapSalesforceQuotaExceededException: AlertingLevel.NONE,
-        InvalidCredentialsError: AlertingLevel.NONE
+        InvalidCredentialsError: AlertingLevel.NONE,
+        TapSalesforceReportRetrievalException: AlertingLevel.NONE,
     }
 
     config_jsonschema = th.PropertiesList(

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -9,7 +9,7 @@ class TapSalesforceQuotaExceededException(TapSalesforceException):
 class TapSalesforceBulkAPIDisabledException(TapSalesforceException):
     pass
 
-class TapSalesforceReportRetrievalException(TapSalesforceException):
+class TapSalesforceReportNotFoundException(TapSalesforceException):
     pass
 
 class RetriableError(TapSalesforceException):

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -9,5 +9,8 @@ class TapSalesforceQuotaExceededException(TapSalesforceException):
 class TapSalesforceBulkAPIDisabledException(TapSalesforceException):
     pass
 
+class TapSalesforceReportRetrievalException(TapSalesforceException):
+    pass
+
 class RetriableError(TapSalesforceException):
     pass

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -4,11 +4,12 @@ import singer
 import singer.utils as singer_utils
 from singer import Transformer, metadata, metrics
 from requests.exceptions import RequestException
+from requests.exceptions import HTTPError
 from tap_salesforce.salesforce.bulk import Bulk
 import base64
 from io import BytesIO
 from openpyxl import load_workbook
-from tap_salesforce.salesforce.exceptions import TapSalesforceReportRetrievalException
+from tap_salesforce.salesforce.exceptions import TapSalesforceReportNotFoundException
 LOGGER = singer.get_logger()
 
 BLACKLISTED_FIELDS = set(['attributes'])
@@ -321,14 +322,16 @@ def get_report_record_ids_from_xlsx(sf, report_ids, stream):
 
                 LOGGER.info(f"Found {len(record_ids)} {stream} IDs from report {report_id}")
 
-            except Exception as e:
-                raise TapSalesforceReportRetrievalException(
-                    f"Error retrieving report {report_id}: {str(e)}"
-                ) from e
+            except HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    raise TapSalesforceReportNotFoundException(
+                        f"Error retrieving report {report_id}: {str(e)}"
+                    ) from e
+                raise
                 
     except Exception as e:
-        if isinstance(e, TapSalesforceReportRetrievalException):
-            raise TapSalesforceReportRetrievalException(
+        if isinstance(e, TapSalesforceReportNotFoundException):
+            raise TapSalesforceReportNotFoundException(
                 f"Error retrieving report data: {str(e)}"
             ) from e
         raise

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -8,6 +8,7 @@ from tap_salesforce.salesforce.bulk import Bulk
 import base64
 from io import BytesIO
 from openpyxl import load_workbook
+from tap_salesforce.salesforce.exceptions import TapSalesforceReportRetrievalException
 LOGGER = singer.get_logger()
 
 BLACKLISTED_FIELDS = set(['attributes'])
@@ -321,10 +322,16 @@ def get_report_record_ids_from_xlsx(sf, report_ids, stream):
                 LOGGER.info(f"Found {len(record_ids)} {stream} IDs from report {report_id}")
 
             except Exception as e:
-                raise Exception(f"Error retrieving report {report_id}: {str(e)}")
+                raise TapSalesforceReportRetrievalException(
+                    f"Error retrieving report {report_id}: {str(e)}"
+                ) from e
                 
     except Exception as e:
-        raise Exception(f"Error retrieving report data: {str(e)}")
+        if isinstance(e, TapSalesforceReportRetrievalException):
+            raise TapSalesforceReportRetrievalException(
+                f"Error retrieving report data: {str(e)}"
+            ) from e
+        raise
 
     return record_ids
 

--- a/tests/test_sync_report_via_excel.py
+++ b/tests/test_sync_report_via_excel.py
@@ -6,7 +6,10 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 from openpyxl import Workbook
 
-from tap_salesforce.sync import sync_report_via_excel
+from hotglue_singer_sdk.helpers.capabilities import AlertingLevel
+from tap_salesforce import SalesforceTap
+from tap_salesforce.salesforce.exceptions import TapSalesforceReportRetrievalException
+from tap_salesforce.sync import get_report_record_ids_from_xlsx, sync_report_via_excel
 from tests.conftest import get_aware_datetime
 
 
@@ -421,3 +424,23 @@ class TestSyncReportViaExcel:
         assert params['xf'] == 'xlsx'
         assert params['data'] == 2
         assert params['includeDetails'] is True
+
+
+class TestReportRetrievalErrors:
+    def test_get_report_record_ids_from_xlsx_raises_explicit_exception(self, mock_sf_client):
+        """Report retrieval failures should raise a typed exception for alert suppression."""
+        mock_sf_client._make_request.side_effect = Exception("404 Client Error: Not Found")
+
+        with pytest.raises(TapSalesforceReportRetrievalException) as exc_info:
+            get_report_record_ids_from_xlsx(mock_sf_client, ["00Oak00000H3b7hEAB"], "Contact")
+
+        assert "Error retrieving report data" in str(exc_info.value)
+        assert "00Oak00000H3b7hEAB" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, TapSalesforceReportRetrievalException)
+
+    def test_report_retrieval_exception_alerting_is_disabled(self):
+        """Typed report retrieval exceptions should not trigger connector alerts."""
+        assert (
+            SalesforceTap.exception_alerting_level_map[TapSalesforceReportRetrievalException]
+            == AlertingLevel.NONE
+        )

--- a/tests/test_sync_report_via_excel.py
+++ b/tests/test_sync_report_via_excel.py
@@ -5,10 +5,11 @@ import pytest
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 from openpyxl import Workbook
+from requests.exceptions import HTTPError
 
 from hotglue_singer_sdk.helpers.capabilities import AlertingLevel
 from tap_salesforce import SalesforceTap
-from tap_salesforce.salesforce.exceptions import TapSalesforceReportRetrievalException
+from tap_salesforce.salesforce.exceptions import TapSalesforceReportNotFoundException
 from tap_salesforce.sync import get_report_record_ids_from_xlsx, sync_report_via_excel
 from tests.conftest import get_aware_datetime
 
@@ -427,20 +428,37 @@ class TestSyncReportViaExcel:
 
 
 class TestReportRetrievalErrors:
-    def test_get_report_record_ids_from_xlsx_raises_explicit_exception(self, mock_sf_client):
-        """Report retrieval failures should raise a typed exception for alert suppression."""
-        mock_sf_client._make_request.side_effect = Exception("404 Client Error: Not Found")
+    def test_get_report_record_ids_from_xlsx_raises_report_not_found_for_404(self, mock_sf_client):
+        """A missing report should raise a typed exception for alert suppression."""
+        response = MagicMock(status_code=404)
+        request = MagicMock()
+        error = HTTPError("404 Client Error: Not Found")
+        error.response = response
+        error.request = request
+        mock_sf_client._make_request.side_effect = error
 
-        with pytest.raises(TapSalesforceReportRetrievalException) as exc_info:
+        with pytest.raises(TapSalesforceReportNotFoundException) as exc_info:
             get_report_record_ids_from_xlsx(mock_sf_client, ["00Oak00000H3b7hEAB"], "Contact")
 
         assert "Error retrieving report data" in str(exc_info.value)
         assert "00Oak00000H3b7hEAB" in str(exc_info.value)
-        assert isinstance(exc_info.value.__cause__, TapSalesforceReportRetrievalException)
+        assert isinstance(exc_info.value.__cause__, TapSalesforceReportNotFoundException)
 
-    def test_report_retrieval_exception_alerting_is_disabled(self):
-        """Typed report retrieval exceptions should not trigger connector alerts."""
+    def test_get_report_record_ids_from_xlsx_reraises_non_404_errors(self, mock_sf_client):
+        """Non-404 report failures should continue to bubble up normally."""
+        response = MagicMock(status_code=500)
+        request = MagicMock()
+        error = HTTPError("500 Server Error")
+        error.response = response
+        error.request = request
+        mock_sf_client._make_request.side_effect = error
+
+        with pytest.raises(HTTPError):
+            get_report_record_ids_from_xlsx(mock_sf_client, ["00Oak00000H3b7hEAB"], "Contact")
+
+    def test_report_not_found_exception_alerting_is_disabled(self):
+        """Missing-report exceptions should not trigger connector alerts."""
         assert (
-            SalesforceTap.exception_alerting_level_map[TapSalesforceReportRetrievalException]
+            SalesforceTap.exception_alerting_level_map[TapSalesforceReportNotFoundException]
             == AlertingLevel.NONE
         )


### PR DESCRIPTION
# Description of change
Raise a dedicated `TapSalesforceReportNotFoundException` only when Contact/Lead report XLSX retrieval returns `404 Not Found`, and suppress alerts for that explicit missing-report exception in `exception_alerting_level_map`.

# QA steps
- [ ] automated tests passing
- [ ] manual qa steps passing (list below)

Automated test execution was not possible in this sandbox because the repo test dependencies are not installed (`pytest`, `singer`, and related packages).

# Risks
Low. This only changes the 404 missing-report path and leaves other report retrieval failures alerting as before.

# Rollback steps
- revert this branch